### PR TITLE
Allow Stoker to create a cache of logo files

### DIFF
--- a/src/Command/StokeCommand.php
+++ b/src/Command/StokeCommand.php
@@ -184,7 +184,7 @@ class StokeCommand extends Command
     {
         if (!file_exists($directory)) {
             $this->logger->notice("Directory '$directory' does not exist yet, creating.");
-            $isCreated = @mkdir($directory, 0700, true);
+            $isCreated = @mkdir($directory, 0755, true);
             if (!$isCreated) {
                 throw new InvalidArgumentException(
                     "'$directory' does not exist and can not be created by the current user. Try: sudo mkdir -p \"$directory\""

--- a/src/Command/StokeCommand.php
+++ b/src/Command/StokeCommand.php
@@ -213,7 +213,10 @@ class StokeCommand extends Command
             return;
         }
 
-        $pathIsUrl = (bool) parse_url($certPath);
+        $schema = parse_url($certPath,PHP_URL_SCHEME);
+        $pathIsUrl = ($schema=='http' or $schema=='https');
+       if ($schema=='file') $certPath = parse_url($certPath, PHP_URL_PATH);
+
         if ($pathIsUrl && !ini_get('allow_url_fopen')) {
             throw new InvalidArgumentException(
                 "Unable to fetch cert from URL '$certPath' because php.ini setting 'allow_url_fopen' is set to Off"
@@ -235,7 +238,10 @@ class StokeCommand extends Command
 
     private function verifyMetadataPath($path)
     {
-        $pathIsUrl = (bool) parse_url($path);
+        $schema = parse_url($path,PHP_URL_SCHEME);
+        $pathIsUrl = ($schema=='http' or $schema=='https');
+       if ($schema=='file') $path = parse_url($path, PHP_URL_PATH);
+
         if ($pathIsUrl && !ini_get('allow_url_fopen')) {
             throw new InvalidArgumentException(
                 "Unable to fetch metadata from URL '$path' because php.ini setting 'allow_url_fopen' is set to Off"

--- a/src/Command/StokeCommand.php
+++ b/src/Command/StokeCommand.php
@@ -336,10 +336,6 @@ class StokeCommand extends Command
 			// Create a cache for the logos - (!) this involves modifying the entityXML to reflect the new logo file locations
 			$entityXml =  $this->createLogoCache($entitySourceXml, "/logoURL/");
 
-			var_dump($entity);
-			var_dump($entityXml);
-
-			exit();
             if ($entity) {
                 $metadataIndex->addEntity($entity);
 
@@ -595,23 +591,13 @@ class StokeCommand extends Command
 
 				$newLogoNode = $document->importNode($newImage, true);
 
-
-				var_dump($oldLogoNode);
-				var_dump($newLogoNode);
-
 				// Replace
 				$replacing = $oldLogoNode->parentNode->replaceChild($newLogoNode, $oldLogoNode);
-
-
-				exit();
-				
-
-				$logo["imageFile"] = $logoName.".".$logoExtention;
-				$logos[] = $logo; 
 			}
 			
 		}
-        return $entityXml;
+		
+        return $document->saveXML();
     }
 
 

--- a/src/Command/StokeCommand.php
+++ b/src/Command/StokeCommand.php
@@ -565,8 +565,13 @@ class StokeCommand extends Command
 
 					// Calculate path
 					$logoBlobHeaderParts = explode("/", $logoBlob[0]);
-					$logoExtention = $logoBlobHeaderParts[1];
-					$imageFileLocation = $logoDirectory . $logoName.".".$logoExtention;
+					if (isset($logoBlobHeaderParts[1])) {
+						$logoExtention = $logoBlobHeaderParts[1];
+						$logoFilename = $logoName.".".$logoExtention;
+					} else {
+						$logoFilename = $logoName;
+					}
+					$imageFileLocation = $logoDirectory . $logoFilename;
 
 					// write down blob into an image file
 					$imageData = explode(',', $content);
@@ -579,8 +584,14 @@ class StokeCommand extends Command
 					$logoLocation = $content;
 
 					$path_parts = pathinfo($logoLocation);
-					$logoExtention = $path_parts['extension'];
-					$imageFileLocation = $logoDirectory . $logoName.".".$logoExtention;
+					if (isset($path_parts['extension'])) {
+						$logoFilename = $logoName.".".$path_parts['extension'];
+					} else {
+						print("Woeps, image url without extension: $logoLocation\n");
+						$logoFilename = $logoName;
+					}
+					$imageFileLocation = $logoDirectory . $logoFilename;
+
 
 					// download URL and replace URL location in Metadata.
 					if ($this->urlExists($logoLocation)) {
@@ -594,7 +605,7 @@ class StokeCommand extends Command
 				// Load the $parent document fragment into the current document
 				
 				
-				$newImage = $document->createElement("mdui:Logo", $this->getURLPathForLogo($entityId).$logoName.".".$logoExtention); 
+				$newImage = $document->createElement("mdui:Logo", $this->getURLPathForLogo($entityId).$logoFilename); 
 
 				$newImageWidth = $document->createAttribute('width');
 				$newImageHeight = $document->createAttribute('height');

--- a/src/Command/StokeCommand.php
+++ b/src/Command/StokeCommand.php
@@ -535,15 +535,11 @@ class StokeCommand extends Command
 					'/md:EntityDescriptor/md:IDPSSODescriptor/md:Extensions/mdui:UIInfo/mdui:Logo'
 				);
 			
-			foreach ($logoNodes as $oldlogoNode) {
+			foreach ($logoNodes as $oldLogoNode) {
 
-				$logo = array();
-
-				var_dump($oldlogoNode);
-
-				$content = $oldlogoNode->textContent;
-				$logo["width"] = $oldlogoNode->attributes->getNamedItem('width')->textContent;
-				$logo["height"] = $oldlogoNode->attributes->getNamedItem('height')->textContent;
+				$content = $oldLogoNode->textContent;
+				$logo["width"] = $oldLogoNode->attributes->getNamedItem('width')->textContent;
+				$logo["height"] = $oldLogoNode->attributes->getNamedItem('height')->textContent;
 				
 				$logoName = md5($entityId) ."_".$logo["width"]."x".$logo["height"];
 
@@ -586,18 +582,28 @@ class StokeCommand extends Command
 				} 		
 				
 				// Load the $parent document fragment into the current document
-				$newImage = $document->createElement("mdui:Logo"); 
-				$newImage->createTextNode($logoBaseURL.$logoName.".".$logoExtention); 
-				$newImage->setAttribute("width", $oldlogoNode->attributes->getNamedItem('width')->textContent);
-				$newImage->setAttribute("height", $oldlogoNode->attributes->getNamedItem('height')->textContent);
+				$newImage = $document->createElement("mdui:Logo", $logoBaseURL.$logoName.".".$logoExtention); 
 
-				var_dump($newImage);
+				$newImageWidth = $document->createAttribute('width');
+				$newImageHeight = $document->createAttribute('height');
+				
+				$newImageWidth->value = $oldLogoNode->attributes->getNamedItem('width')->textContent;
+				$newImageHeight->value = $oldLogoNode->attributes->getNamedItem('height')->textContent;
+
+				$newImage->appendChild($newImageWidth);
+				$newImage->appendChild($newImageHeight);
+
+				$newLogoNode = $document->importNode($newImage, true);
+
+
+				var_dump($oldLogoNode);
+				var_dump($newLogoNode);
+
+				// Replace
+				$replacing = $oldLogoNode->parentNode->replaceChild($newLogoNode, $oldLogoNode);
+
 
 				exit();
-
-// Replace
-$oldLogoNode->parentNode->replaceChild($newLogoNode, $oldLogoNode);
-
 				
 
 				$logo["imageFile"] = $logoName.".".$logoExtention;
@@ -605,7 +611,7 @@ $oldLogoNode->parentNode->replaceChild($newLogoNode, $oldLogoNode);
 			}
 			
 		}
-        return $entity;
+        return $entityXml;
     }
 
 


### PR DESCRIPTION
Stocker currently retains the pointers to the logos of IdPs at the remote site. This is very slow for discovery, may contain errors and also poses problems from a privacy point of view.
Stoker should be configurable to create a local image cache
